### PR TITLE
support absolute tag in img src

### DIFF
--- a/Sources/ResponsivePublishPlugin/ImageResource.swift
+++ b/Sources/ResponsivePublishPlugin/ImageResource.swift
@@ -94,8 +94,11 @@ struct ImageRewrite: Equatable {
             fileName: String,
             `extension`: ImageFormat
         ) {
-            var pathString = path.absoluteString.drop(while: { $0 == "/" })
-            pathString = pathString.dropLast(pathString.last == "/" ? 1 : 0)
+            var pathString = path.absoluteString
+            if !path.string.hasPrefix("/") {
+                pathString = String(pathString.drop(while: { $0 == "/" }))
+            }
+            pathString = String(pathString.dropLast(pathString.last == "/" ? 1 : 0))
             self.path = Path("\(pathString)")
             self.fileName = fileName
             self.`extension` = `extension`
@@ -119,8 +122,10 @@ struct ImageRewrite: Equatable {
             var pathPrefix = path1.count > path2.count ? path1: path2
             pathPrefix
                 .removeLast(containedPath.commonPrefix(with: prefixedPath).count)
-            pathPrefix
-                .removeFirst()
+            if !self.path.string.hasPrefix("/") {
+                pathPrefix
+                    .removeFirst()
+            }
             pathPrefix += "/"
             
             return Path(pathPrefix)

--- a/Sources/ResponsivePublishPlugin/RewriteEngine/URLParser.swift
+++ b/Sources/ResponsivePublishPlugin/RewriteEngine/URLParser.swift
@@ -9,7 +9,7 @@ import Foundation
 import Publish
 import SwiftGD
 
-fileprivate let imageTagPattern: String = #"<img\s*(?:src\s*\=\s*[\'\"]((\.\.\/|[A-Za-z-_\+\d]+\/)*)([A-Za-z-_\+\d]*).(jpg|png)[\'\"].*?\s*|[a-z]+?\s*\=\s*[\'\"].*?[\'\"].*?\s*)+[\s\/]*?>"#
+fileprivate let imageTagPattern: String = #"<img\s*(?:src\s*\=\s*[\'\"](\/?(\.\.\/|[A-Za-z-_\+\d]+\/)*)([A-Za-z-_\+\d]*).(jpg|png)[\'\"].*?\s*|[a-z]+?\s*\=\s*[\'\"].*?[\'\"].*?\s*)+[\s\/]*?>"#
 fileprivate let imagePathPattern: String = #"url\(['"]?((\.\.\/|[A-Za-z-_\+\d]+\/)*)([A-Za-z-_\+\d]*).(jpg|png){1}['"]?\);"#
 
 /// Extracts Image URLs from a given HTML file, looking for img-tags and the corresponding src-attribute

--- a/Tests/ResponsivePublishPluginTests/Expected/index-expected.html
+++ b/Tests/ResponsivePublishPluginTests/Expected/index-expected.html
@@ -12,6 +12,7 @@
         </a>
         <img srcset="assets/img-optimized/background-extra-small.webp 600w, assets/img-optimized/background-small.webp 900w, assets/img-optimized/background-normal.webp 1200w, assets/img-optimized/background-large.webp 1800w" src="assets/img/background.jpg" alt="Background" width="500" height="600" />
         <img srcset="assets/img-optimized/background-extra-small.webp 600w, assets/img-optimized/background-small.webp 900w, assets/img-optimized/background-normal.webp 1200w, assets/img-optimized/background-large.webp 1800w" src="assets/img/background.jpg" />
+        <img srcset="/assets/img-optimized/background-extra-small.webp 600w, /assets/img-optimized/background-small.webp 900w, /assets/img-optimized/background-normal.webp 1200w, /assets/img-optimized/background-large.webp 1800w" src="/assets/img/background.jpg" />
     </body>
 </html>
 

--- a/Tests/ResponsivePublishPluginTests/Resources/index.html
+++ b/Tests/ResponsivePublishPluginTests/Resources/index.html
@@ -12,6 +12,7 @@
         </a>
         <img src="assets/img/background.jpg" alt="Background" width="500" height="600" />
         <img src="assets/img/background.jpg" />
+        <img src="/assets/img/background.jpg" />
     </body>
 </html>
 


### PR DESCRIPTION
Hello again! This PR adds support for image tags that start with `/` (absolute url that resolves to the base path), e.g:
```html
<img src="/assets/img/background.jpg" />
```

Before, these tags were not rewritten at all in html files. After this PR, they should be resolved correctly to:
```html
<img srcset="/assets/img-optimized/background-extra-small.webp 600w, 
             /assets/img-optimized/background-small.webp 900w, 
             /assets/img-optimized/background-normal.webp 1200w, 
             /assets/img-optimized/background-large.webp 1800w" 
     src="/assets/img/background.jpg" 
/>
```
Although it may not be the cleanest of fixes (maybe you can find a better way!), all tests are still passing 😄 
