### PR TITLE
Allow image exclusion

### DIFF
--- a/Sources/ResponsivePublishPlugin/ResponsivePublishPlugin.swift
+++ b/Sources/ResponsivePublishPlugin/ResponsivePublishPlugin.swift
@@ -18,12 +18,14 @@ extension Plugin {
     public static func generateOptimizedImages(
         from: Path = Path("Resources/assets/img"),
         at: Path = Path("assets/img-optimized"),
-        rewriting stylesheet: Path = Path("assets/css/styles.css")) -> Self
+        rewriting stylesheet: Path = Path("assets/css/styles.css"),
+        excluding: [String] = []) -> Self
     {
         Plugin(name: "Responsive") { context in
             let urls: [URL] = try context
                 .folder(at: from)
                 .files
+                .filter({ !excluding.contains($0.name) })
                 .reduce([URL]()) { current, file in
                     current + [URL(fileURLWithPath: file.path)]
                 }

--- a/Tests/ResponsivePublishPluginTests/Resources/index-with-exclusion.html
+++ b/Tests/ResponsivePublishPluginTests/Resources/index-with-exclusion.html
@@ -1,0 +1,2 @@
+<img src="assets/img/background.jpg" />
+<img src="assets/img/background-exclude.jpg" />

--- a/Tests/ResponsivePublishPluginTests/ResponsivePublishPluginTests.swift
+++ b/Tests/ResponsivePublishPluginTests/ResponsivePublishPluginTests.swift
@@ -197,6 +197,38 @@ final class ResponsivePublishPluginTests: XCTestCase {
         XCTAssertEqual(output, expected)
     }
     
+    func testImageExclusion() throws {
+        try TestWebsite().publish(
+            at: Self.testDirPath,
+            using: [
+                .copyResources(),
+                .installPlugin(
+                    .generateOptimizedImages(
+                        from: resourcesFolderPath.appendingComponent("img"),
+                        at: Path("img-optimized"),
+                        rewriting: Path("css/styles.css"),
+                        excluding: ["background-exclude.jpg"]
+                    )
+                )
+            ]
+        )
+        
+        let output = try? outputFolder?
+            .file(at: "index-with-exclusion.html")
+            .readAsString()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .filter { !" \n\t\r".contains($0) }
+        
+        let expected = """
+        <img srcset="assets/img-optimized/background-extra-small.webp 600w, assets/img-optimized/background-small.webp 900w, assets/img-optimized/background-normal.webp 1200w, assets/img-optimized/background-large.webp 1800w" src="assets/img/background.jpg" />
+        <img src="assets/img/background-exclude.jpg" />
+        """
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .filter { !" \n\t\r".contains($0) }
+        
+        XCTAssertEqual(output, expected)
+    }
+    
     func testImagesForSizeClassesAreCreated() throws {
         try TestWebsite().publish(
             at: Self.testDirPath,


### PR DESCRIPTION
Allows specific images to be excluded from being optimized, e.g:

```swift
.generateOptimizedImages(
    /* ... */
    excluding: ["img-to-exclude.jpg"]
)
```